### PR TITLE
Fixing memory management bug for the start loading block

### DIFF
--- a/ILCannedURLProtocol.m
+++ b/ILCannedURLProtocol.m
@@ -47,7 +47,8 @@ static CGFloat gILResponseDelay = 0;
 @implementation ILCannedURLProtocol
 
 + (void)setStartLoadingBlock:(void(^)(NSURLRequest *request))block {
-    startLoadingBlock = block;
+    Block_release(startLoadingBlock);
+    startLoadingBlock = Block_copy(block);
 }
 
 + (BOOL)canInitWithRequest:(NSURLRequest *)request {


### PR DESCRIPTION
I forgot that ILTesting doesn't use ARC :)
