### PR TITLE
Apply the network delay to failed requests

### DIFF
--- a/ILCannedURLProtocol.m
+++ b/ILCannedURLProtocol.m
@@ -160,6 +160,7 @@ static CGFloat gILResponseDelay = 0;
 
 	
 	if (gILCannedError) {
+		[NSThread sleepForTimeInterval:gILResponseDelay];
 		[client URLProtocol:self didFailWithError:gILCannedError];
 		
 	} else {


### PR DESCRIPTION
Currently, when a global error is set, the global response delay is bypassed.

This commit ensures that when a global error is set, the network thread will wait for the global response delay before responding with the error.
